### PR TITLE
Fix call to load_all() on empty TCK file

### DIFF
--- a/tractconverter/formats/tck.py
+++ b/tractconverter/formats/tck.py
@@ -226,7 +226,7 @@ class TCK:
 
     def load_all(self):
         if self.hdr[Header.NB_FIBERS] == 0:
-            return
+            return []
         
         with open(self.filename, 'rb') as f:
             f.seek(self.offset)


### PR DESCRIPTION
This fixes issue #13.
