### PR TITLE
BF: correctly handle section tags case in VTK format

### DIFF
--- a/tractconverter/formats/vtk.py
+++ b/tractconverter/formats/vtk.py
@@ -121,7 +121,7 @@ def get_sections(filename):
     with open(filename, 'rb') as f:
         for line in f:
             for section in POLYDATA_SECTIONS:
-                if line.startswith(section):
+                if line.upper().startswith(section):
                     if section in sections_found:
                         print "Warning multiple {0} sections!".format(section)
 


### PR DESCRIPTION
According to the VTK format standard, keywords are case-insensitive. Currently, we were looking for the upper case version of the section names. Got a vtk file where the ```LINES``` keyword was cased as ```Lines```, causing the TC to not find any line to convert.

Now, we test against the upper-cased line.